### PR TITLE
lwksched: fix CPU assignment during overcommmit

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2798,8 +2798,7 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
 	p->rt.time_slice	= sched_rr_timeslice;
 	p->rt.on_rq		= 0;
 	p->rt.on_list		= 0;
-	init_run_list_mos(p);
-	init_util_list_mos(p);
+	init_fork_mos(p);
 
 #ifdef CONFIG_PREEMPT_NOTIFIERS
 	INIT_HLIST_HEAD(&p->preempt_notifiers);

--- a/kernel/sched/mos.h
+++ b/kernel/sched/mos.h
@@ -143,6 +143,14 @@ static inline bool is_migration_mask_valid_mos(const cpumask_t *mask,
 	return false;
 }
 
+static inline void init_fork_mos(struct task_struct *p)
+{
+	p->mos.cpu_home = -1;
+	p->mos.thread_type = mos_thread_type_normal;
+	init_run_list_mos(p);
+	init_util_list_mos(p);
+}
+
 #else
 
 static inline void assimilate_mos(struct rq *rq, struct task_struct *p)
@@ -235,6 +243,9 @@ static inline bool is_migration_mask_valid_mos(const cpumask_t *mask,
 {
 	return false;
 }
+
+static inline void init_fork_mos(struct task_struct *p)
+{}
 
 #endif
 


### PR DESCRIPTION
When CPUs are overcommitted in an LWK partition, the
additional threads were being assigned to the CPU of the thread that
created the new threads. For example, if 10 CPUs were in the
reservation for the process and 100 threads were created by the
main thread of the process, there would be 1 thread running on each
of the upper 9 CPUs and 91 threads all trying to all run on
the first CPU of the reservation. This mOS problem was
introduced during a recent rebase in which Linux changed the clone
system call code flow.

Change-Id: I068dd29ebdb8dc195798a68ef268f5719247e59d
Signed-off-by: John Attinella <john.e.attinella@intel.com>